### PR TITLE
Propagate the entire fsnotify event through to handlers

### DIFF
--- a/watcher_test.go
+++ b/watcher_test.go
@@ -1,0 +1,53 @@
+package gocommon
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+func TestFSNotifyHandlerMiddlewareAnyOf(t *testing.T) {
+	tests := []struct {
+		name      string
+		event     fsnotify.Event
+		allow     fsnotify.Op
+		allowRest []fsnotify.Op
+		want      map[fsnotify.Op]struct{}
+	}{
+		{
+			name:  "only writes",
+			event: fsnotify.Event{Op: fsnotify.Write},
+			allow: fsnotify.Write,
+			want:  map[fsnotify.Op]struct{}{fsnotify.Write: {}},
+		},
+		{
+			name:  "discard chmod because it is not write",
+			event: fsnotify.Event{Op: fsnotify.Chmod},
+			allow: fsnotify.Write,
+			want:  map[fsnotify.Op]struct{}{},
+		},
+		{
+			name:      "allow chmod since it is on the list",
+			event:     fsnotify.Event{Op: fsnotify.Chmod},
+			allow:     fsnotify.Write,
+			allowRest: []fsnotify.Op{fsnotify.Chmod},
+			want:      map[fsnotify.Op]struct{}{fsnotify.Chmod: {}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := make(map[fsnotify.Op]struct{})
+			handler := FSNotifyHandlerFunc(func(event fsnotify.Event) {
+				got[event.Op] = struct{}{}
+			})
+
+			AnyOf(handler, tt.allow, tt.allowRest...).Notify(tt.event)
+
+			if !reflect.DeepEqual(tt.want, got) {
+				t.Errorf("want accept=%+v, got accept=%+v", tt.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
And while in there, also add some middleware to avoid callers from having to write boilerplate about filtering the events they are interested in.

As some additional context behind this breaking change: I am re-using WatchFileChange as part of my patches for issue 3902 (linked below) but I wanted my monitor code to be able to respond to more than just writes (remove, rename, etc) and I also wanted it to know specifically what the event type was. For example, if the code knows the file was removed, there's no need to try checksumming the contents of a file that's no longer there.

Since this a breaking change, here's an example of what updating the client callsites looks like:

```diff
diff --git a/pkg/monitor/file.go b/pkg/monitor/file.go
index 5818892..f06b261 100644
--- a/pkg/monitor/file.go
+++ b/pkg/monitor/file.go
@@ -3,6 +3,7 @@ package monitor
 import (
        "context"

+       "github.com/fsnotify/fsnotify"
        gocommon "github.com/harvester/go-common"
        "github.com/sirupsen/logrus"
        metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -35,7 +36,10 @@ func NewConfigFileMonitor(ctx context.Context, nodecfg ctlv1.NodeConfigControlle

 func (monitor *ConfigFileMonitor) startMonitor() {
        go func() {
-               gocommon.WatchFileChange(monitor.Context, monitor.genericHandler, monitorTargets)
+               handler := gocommon.FSNotifyHandlerFunc(func(event fsnotify.Event) {
+                       monitor.genericHandler(event.Name)
+               })
+               gocommon.WatchFileChange(monitor.Context, gocommon.AnyOf(gocommon.FSNotifyHandlerFunc(handler), fsnotify.Write), monitorTargets)
        }()
 }
 ```
 
 That said, if there is no interest in accepting a breaking change, we can close this PR and I will just implement the equivalent of `WatchFileChange` as part of my overall changeset for 3902.

Related-to: https://github.com/harvester/harvester/issues/3902