### PR TITLE
bump go to v1.20.10

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/harvester/go-common
 
-go 1.19
+go 1.20
 
 require (
 	github.com/coreos/go-systemd/v22 v22.5.0


### PR DESCRIPTION
**Problem:**
We used go 1.19, which is EOL in 2023/08.

**Solution:**
Bump golang to v1.20.10.

**Related Issue:**
https://github.com/harvester/security/issues/38
